### PR TITLE
Fix kernel compilation problem.

### DIFF
--- a/TCanny/TCannyCL.cpp
+++ b/TCanny/TCannyCL.cpp
@@ -21,6 +21,7 @@
 **   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
+#include <clocale>
 #include "TCanny.hpp"
 #include "TCanny.cl"
 
@@ -301,6 +302,7 @@ void VS_CC tcannyCLCreate(const VSMap *in, VSMap *out, void *userData, VSCore *c
 
         compute::program program = compute::program::create_with_source(source, ctx);
         try {
+            std::setlocale(LC_ALL, "C");
             std::string options{ "-cl-denorms-are-zero -cl-fast-relaxed-math -Werror" };
             options += " -D T_H=" + std::to_string(t_h);
             options += " -D T_L=" + std::to_string(t_l);


### PR DESCRIPTION
I've got that error log when tried to use OpenCL version. Proposed changes fixed that problem. 
```
vapoursynth.Error: TCannyCL: Build Program Failure
:167:21: warning: expression result unused
if (!label[pos] && buffer[pos] >= T_H) { 
~~~~~~~~~~~ ^ ~~~~~~~~~~~~~~~~~~
:195:38: warning: expression result unused
if (!label[pos3] && buffer[pos3] >= T_L) { 
~~~~~~~~~~~~ ^ ~~~~~~~~~~~~~~~~~~~
:264:42: warning: expression result unused
const uint output = min((uint)(input * MAGNITUDE + 0.5f), peak); 
~~~~~ ^ ~~~~~~~~~
:274:34: error: expected identifier or '('
const float output = input * MAGNITUDE - offset; 
^
:23:21: note: expanded from here
#define MAGNITUDE 5,100000
^
:274:34: error: expected ';' at end of declaration
:23:21: note: expanded from here
#define MAGNITUDE 5,100000
^
```